### PR TITLE
新增链接转换text参数配置

### DIFF
--- a/src/Requests/ApiGetReferralLinkRequest.php
+++ b/src/Requests/ApiGetReferralLinkRequest.php
@@ -54,6 +54,11 @@ class ApiGetReferralLinkRequest extends AbstractRequest
     private $bizLine;
 
     /**
+     * 活动链接.
+     */
+    private $text;
+
+    /**
      * 请求参数.
      */
     private $apiParams = [];
@@ -158,6 +163,15 @@ class ApiGetReferralLinkRequest extends AbstractRequest
     {
         $this->bizLine = $bizLine;
         $this->apiParams['bizLine'] = $bizLine;
+    }
+
+    /**
+     * @param string $text
+     */
+    public function setText($text)
+    {
+        $this->text = $text;
+        $this->apiParams['text'] = $text;
     }
 
     public function getApiParams(): array


### PR DESCRIPTION
活动链接，即想要推广的目标链接，出参会返回成自己可推的链接，限定为当前可推广的活动链接或者商品券链接，请求内容尽量保持在200字以内，文本中仅存在一个http协议头的链接