### PR TITLE
feat(api): 增加分享文案类型参数支持

### DIFF
--- a/src/Requests/ApiGetReferralLinkRequest.php
+++ b/src/Requests/ApiGetReferralLinkRequest.php
@@ -54,7 +54,18 @@ class ApiGetReferralLinkRequest extends AbstractRequest
     private $bizLine;
 
     /**
+     * 分享文案：支持媒体选择小红书 or 微信社群风格的分享文案 出参增加 shareText 字段
+     * 1 代表小红书风格文案
+     * 2 代表微信社群风格文案.
+     *
+     * 是否必须：否
+     * @var int
+     */
+    private $shareTextType;
+
+    /**
      * 活动链接.
+     * @var string
      */
     private $text;
 
@@ -165,6 +176,11 @@ class ApiGetReferralLinkRequest extends AbstractRequest
         $this->apiParams['bizLine'] = $bizLine;
     }
 
+    public function getText()
+    {
+        return $this->text;
+    }
+
     /**
      * @param string $text
      */
@@ -172,6 +188,17 @@ class ApiGetReferralLinkRequest extends AbstractRequest
     {
         $this->text = $text;
         $this->apiParams['text'] = $text;
+    }
+
+    public function getShareTextType()
+    {
+        return $this->shareTextType;
+    }
+
+    public function setShareTextType($shareTextType)
+    {
+        $this->shareTextType = $shareTextType;
+        $this->apiParams['shareTextType'] = $shareTextType;
     }
 
     public function getApiParams(): array

--- a/src/Utils/SignUtil.php
+++ b/src/Utils/SignUtil.php
@@ -51,10 +51,10 @@ class SignUtil
      */
     public static function sign($config, $signHeaders): string
     {
-        $strSign = self::httpMethod($config) . "\n" .
-            self::contentMD5($config) . "\n" .
-            self::headers($signHeaders) .
-            self::url($config);
+        $strSign = self::httpMethod($config) . "\n"
+            . self::contentMD5($config) . "\n"
+            . self::headers($signHeaders)
+            . self::url($config);
         $key = $config['secret'] ?? '';
         $hash = hash_hmac('sha256', $strSign, $key, true);
         return base64_encode($hash);


### PR DESCRIPTION
…e 字段- 支持小红书和微信社群两种文案风格的选择

- 新增 getText 和 getShareTextType 方法用于获取参数值
- 更新 SignUtil 类中的签名字符串拼接逻辑以提高可读性